### PR TITLE
Support for nested dispatch calls on Store

### DIFF
--- a/src/Redux.Tests/StoreTests.cs
+++ b/src/Redux.Tests/StoreTests.cs
@@ -1,5 +1,8 @@
 ﻿using NUnit.Core;
 using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Reactive.Linq;
 
 namespace Redux.Tests
 {
@@ -59,6 +62,23 @@ namespace Redux.Tests
 
             Assert.AreEqual(1, numberOfCalls);
             CollectionAssert.AreEqual(new[] { 1, 2 }, mockObserver.Values);
+        }
+
+        [Test]
+        public void Should_push_state_to_end_of_queue_on_nested_dispatch()
+        {
+            var sut = new Store<int>(1, Reducers.Replace);
+            var mockObserver = new MockObserver<int>();
+            sut.Subscribe(val =>
+            {
+                if (val < 5)
+                {
+                    sut.Dispatch(new FakeAction<int>(val + 1));
+                }
+                mockObserver.OnNext(val);
+            });
+
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5 }, mockObserver.Values);
         }
     }
 }

--- a/src/Redux/Store.cs
+++ b/src/Redux/Store.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
@@ -38,7 +39,9 @@ namespace Redux
         
         public IDisposable Subscribe(IObserver<TState> observer)
         {
-            return _stateSubject.Subscribe(observer);
+            return _stateSubject
+                .ObserveOn(Scheduler.CurrentThread)
+                .Subscribe(observer);
         }
 
         private Dispatcher ApplyMiddlewares(params Middleware<TState>[] middlewares)


### PR DESCRIPTION
Nested dispatch calls will (1) cause an invalid application state in
Store and (2) could potentially cause a stack overflow.
1. Invalid application state example
   a. I have a Store that contains an Application State, contains 2 properties

```
class ApplicationState {
  public int Count {get; set;}
  public string LatestName {get; set;}
}
```

b. Application state initialized with Count = 1, LatestName = Bob
c. I have a WPF MVVM app that binds both properties to textblocks
d. In the View Model's constructor, we subscribe to the Store with the following logic:

```
if (count == 1) {
  // Dispatch new action that changes count = count + 1, and latestName = Carl.
}
Count = state.count;
LatestName = state.LatestName;
```

e. App ends up with Count = 1, LatestName = Bob
1. Stack overflow example

```
var store = new Store<int>(1);
store.Subscribe(state =>
{
  store.Dispatch(new StateAction(state + 1));
  // Print state.val
});
```
