### PR TITLE
Breaking change: Store<T> use events instead of implementing IObservable<T>.

### DIFF
--- a/src/Redux.DevTools.Universal/Redux.DevTools.Universal.csproj
+++ b/src/Redux.DevTools.Universal/Redux.DevTools.Universal.csproj
@@ -135,6 +135,10 @@
       <Project>{6c83c892-15ea-4b7c-b7e4-87bd104bf444}</Project>
       <Name>Redux.DevTools</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Redux\Redux.csproj">
+      <Project>{a15d3f17-691f-48df-9078-27dcde7141eb}</Project>
+      <Name>Redux</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/src/Redux.DevTools.Universal/TimeMachine.xaml.cs
+++ b/src/Redux.DevTools.Universal/TimeMachine.xaml.cs
@@ -27,24 +27,19 @@ namespace Redux.DevTools.Universal
             var oldTimeMachineStore = args.OldValue as IStore<TimeMachineState>;
             if(oldTimeMachineStore != null)
             {
-                timeMachine._storeSubscription.Dispose();
+                oldTimeMachineStore.StateChanged -= timeMachine.OnStateChange;
             }
 
             var newTimeMachineStore = args.NewValue as IStore<TimeMachineState>;
             if(newTimeMachineStore != null)
             {
-                timeMachine.SubscribeToTimeMachineStore();
+                newTimeMachineStore.StateChanged -= timeMachine.OnStateChange;
             }
         }
         
         public TimeMachine()
         {
             this.InitializeComponent();
-        }
-
-        private void SubscribeToTimeMachineStore()
-        {
-            _storeSubscription = TimeMachineStore.Subscribe(OnStateChange);
         }
 
         private void OnStateChange(TimeMachineState state)

--- a/src/Redux.DevTools.WPF/Redux.DevTools.WPF.csproj
+++ b/src/Redux.DevTools.WPF/Redux.DevTools.WPF.csproj
@@ -87,6 +87,10 @@
       <Project>{6c83c892-15ea-4b7c-b7e4-87bd104bf444}</Project>
       <Name>Redux.DevTools</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Redux\Redux.csproj">
+      <Project>{a15d3f17-691f-48df-9078-27dcde7141eb}</Project>
+      <Name>Redux</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Redux.DevTools.WPF/TimeMachine.xaml.cs
+++ b/src/Redux.DevTools.WPF/TimeMachine.xaml.cs
@@ -26,24 +26,19 @@ namespace Redux.DevTools.WPF
             var oldTimeMachineStore = args.OldValue as IStore<TimeMachineState>;
             if (oldTimeMachineStore != null)
             {
-                timeMachine._storeSubscription.Dispose();
+                oldTimeMachineStore.StateChanged -= timeMachine.OnStateChange;
             }
 
             var newTimeMachineStore = args.NewValue as IStore<TimeMachineState>;
             if (newTimeMachineStore != null)
             {
-                timeMachine.SubscribeToTimeMachineStore();
+                newTimeMachineStore.StateChanged -= timeMachine.OnStateChange;
             }
         }
 
         public TimeMachine()
         {
             this.InitializeComponent();
-        }
-
-        private void SubscribeToTimeMachineStore()
-        {
-            _storeSubscription = TimeMachineStore.Subscribe(OnStateChange);
         }
 
         private void OnStateChange(TimeMachineState state)

--- a/src/Redux.DevTools/Redux.DevTools.csproj
+++ b/src/Redux.DevTools/Redux.DevTools.csproj
@@ -44,6 +44,12 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Redux\Redux.csproj">
+      <Project>{a15d3f17-691f-48df-9078-27dcde7141eb}</Project>
+      <Name>Redux</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Redux.DevTools/TimeMachineStore.cs
+++ b/src/Redux.DevTools/TimeMachineStore.cs
@@ -1,27 +1,46 @@
 ﻿using System;
-using System.Linq;
-using System.Reactive.Linq;
+using System.Collections.Generic;
 
 namespace Redux.DevTools
 {
+    /// Todo : Refactor to use StoreEnhancer
     public class TimeMachineStore<TState> : Store<TimeMachineState>, IStore<TState>
     {
+        private Dictionary<Action<TState>, Action<TimeMachineState>> _handlersDictionary = new Dictionary<Action<TState>, Action<TimeMachineState>>();
+
         public TimeMachineStore(Reducer<TState> reducer, TState initialState = default(TState))
             : base(new TimeMachineReducer((state, action) => reducer((TState)state, action)).Execute, new TimeMachineState(initialState))
         {
         }
-
-        public IDisposable Subscribe(IObserver<TState> observer)
+        
+        event Action<TState> IStore<TState>.StateChanged
         {
-            return ((IObservable<TimeMachineState>)this)
-                .Select(state => (TState)state.States[state.Position])
-                .DistinctUntilChanged()
-                .Subscribe(observer);
+            add
+            {
+                var liftedHandler = LiftHandler(value);
+                this._handlersDictionary.Add(value, liftedHandler);
+                this.StateChanged += liftedHandler;
+            }
+            remove
+            {
+                this.StateChanged -= _handlersDictionary[value];
+                _handlersDictionary.Remove(value);
+            }
         }
-
+        
         TState IStore<TState>.GetState()
         {
-            return ((IStore<TState>)this).GetState();
+            return Unlift(GetState());
+        }
+
+        private Action<TimeMachineState> LiftHandler(Action<TState> handler)
+        {
+            return timeMachineState => handler(Unlift(timeMachineState)); 
+        }
+        
+        private TState Unlift(TimeMachineState state)
+        {
+            return (TState)state.States[state.Position];
         }
     }
 }

--- a/src/Redux.Tests/MockObserver.cs
+++ b/src/Redux.Tests/MockObserver.cs
@@ -3,26 +3,12 @@ using System.Collections.Generic;
 
 namespace Redux.Tests
 {
-    public class MockObserver<T> : IObserver<T>
+    public class MockObserver<T>
     {
-        public bool IsCompleted { get; private set; }
-
-        public Exception Error { get; private set; }
-
         private readonly List<T> _values = new List<T>();
         public IEnumerable<T> Values => _values;
 
-        public void OnCompleted()
-        {
-            IsCompleted = true;
-        }
-
-        public void OnError(Exception error)
-        {
-            Error = error;
-        }
-
-        public void OnNext(T value)
+        public void StateChangedHandler(T value)
         {
             _values.Add(value);
         }

--- a/src/Redux.Tests/ObservableStoreTests.cs
+++ b/src/Redux.Tests/ObservableStoreTests.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using Redux.Reactive;
+using System;
+
+namespace Redux.Tests
+{
+    public class ObservableStoreTests
+    {
+        [Test]
+        public void Should_push_state_on_dispatch()
+        {
+            var sut = new ObservableStore<int>(new Store<int>(Reducers.Replace, 1));
+            var mockObserver = new MockObserver<int>();
+
+            sut.Subscribe(mockObserver.StateChangedHandler);
+            sut.Dispatch(new FakeAction<int>(2));
+
+            CollectionAssert.AreEqual(new[] { 1, 2 }, mockObserver.Values);
+        }
+    }
+}

--- a/src/Redux.Tests/Redux.Tests.csproj
+++ b/src/Redux.Tests/Redux.Tests.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FakeAction.cs" />
+    <Compile Include="ObservableStoreTests.cs" />
     <Compile Include="Reducers.cs" />
     <Compile Include="StoreTests.cs" />
     <Compile Include="MockObserver.cs" />

--- a/src/Redux.Tests/Redux.Tests.csproj
+++ b/src/Redux.Tests/Redux.Tests.csproj
@@ -95,6 +95,12 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Redux\Redux.csproj">
+      <Project>{a15d3f17-691f-48df-9078-27dcde7141eb}</Project>
+      <Name>Redux</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Redux.Tests/StoreTests.cs
+++ b/src/Redux.Tests/StoreTests.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Core;
 using NUnit.Framework;
-using System;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -16,7 +15,7 @@ namespace Redux.Tests
             var sut = new Store<int>(Reducers.PassThrough, 1);
             var mockObserver = new MockObserver<int>();
 
-            sut.Subscribe(mockObserver);
+            sut.StateChanged += mockObserver.StateChangedHandler;
 
             CollectionAssert.AreEqual(new[] { 1 }, mockObserver.Values);
         }
@@ -27,7 +26,7 @@ namespace Redux.Tests
             var sut = new Store<int>(Reducers.Replace, 1);
             var mockObserver = new MockObserver<int>();
 
-            sut.Subscribe(mockObserver);
+            sut.StateChanged += mockObserver.StateChangedHandler;
             sut.Dispatch(new FakeAction<int>(2));
 
             CollectionAssert.AreEqual(new[] { 1, 2 }, mockObserver.Values);
@@ -40,7 +39,7 @@ namespace Redux.Tests
             var mockObserver = new MockObserver<int>();
 
             sut.Dispatch(new FakeAction<int>(2));
-            sut.Subscribe(mockObserver);
+            sut.StateChanged += mockObserver.StateChangedHandler;
 
             CollectionAssert.AreEqual(new[] { 2 }, mockObserver.Values);
         }
@@ -57,8 +56,8 @@ namespace Redux.Tests
 
             var sut = new Store<int>(Reducers.Replace, 1, spyMiddleware);
             var mockObserver = new MockObserver<int>();
-            
-            sut.Subscribe(mockObserver);
+
+            sut.StateChanged += mockObserver.StateChangedHandler;
             sut.Dispatch(new FakeAction<int>(2));
 
             Assert.AreEqual(1, numberOfCalls);
@@ -71,13 +70,13 @@ namespace Redux.Tests
         {
             var sut = new Store<int>(Reducers.Replace, 1);
             var mockObserver = new MockObserver<int>();
-            sut.Subscribe(val =>
+            sut.StateChanged += (val =>
             {
                 if (val < 5)
                 {
                     sut.Dispatch(new FakeAction<int>(val + 1));
                 }
-                mockObserver.OnNext(val);
+                mockObserver.StateChangedHandler(val);
             });
 
             CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5 }, mockObserver.Values);

--- a/src/Redux/Delegates.cs
+++ b/src/Redux/Delegates.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Redux
+{
+    public delegate object Dispatcher(object action);
+
+    public delegate TState Reducer<TState>(TState previousState, object action);
+
+    public delegate Func<Dispatcher, Dispatcher> Middleware<TState>(IStore<TState> store);
+}

--- a/src/Redux/ObservableStore.cs
+++ b/src/Redux/ObservableStore.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Reactive.Linq;
+
+namespace Redux.Reactive
+{
+    public interface IObservableStore<TState> : IObservable<TState>
+    {
+        TState GetState();
+
+        object Dispatch(object dispatch);
+    }
+
+    public class ObservableStore<TState> : IObservableStore<TState>
+    {
+        private IStore<TState> _innerStore;
+
+        public ObservableStore(IStore<TState> innerStore)
+        {
+            _innerStore = innerStore;
+        }
+
+        public TState GetState()
+        {
+            return _innerStore.GetState();
+        }
+
+        public object Dispatch(object action)
+        {
+            return _innerStore.Dispatch(action);
+        }
+
+        public IDisposable Subscribe(IObserver<TState> observer)
+        {
+            return Observable.FromEvent<TState>(
+                h => _innerStore.StateChanged += h,
+                h => _innerStore.StateChanged -= h)
+                .Subscribe(observer);
+        }
+    }
+}

--- a/src/Redux/Redux.csproj
+++ b/src/Redux/Redux.csproj
@@ -35,6 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Delegates.cs" />
+    <Compile Include="ObservableStore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Store.cs" />
   </ItemGroup>


### PR DESCRIPTION
Motivation : #51 

Store is now event based. The code is now really closed to [Yarni](https://github.com/cmeeren/yarni)!

I created a ObservableStore that can wrap an IStore instance to expose it as observable. Not sure this breaking change is acceptable...

Ignore the time TimeMachine changes. It should be refactored to use store enhancer.