### PR TITLE
ObserveState extension

### DIFF
--- a/src/Redux.Tests/Reactive/StoreExtensionsTests.cs
+++ b/src/Redux.Tests/Reactive/StoreExtensionsTests.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using Redux.Reactive;
+using System;
+
+namespace Redux.Tests.Reactive
+{
+    public class StoreExtensionsTests
+    {
+        [Test]
+        public void ObserveState_should_push_store_states()
+        {
+            var sut = new Store<int>(Reducers.Replace, 1);
+            var mockObserver = new MockObserver<int>();
+
+            sut.ObserveState().Subscribe(mockObserver.StateChangedHandler);
+            sut.Dispatch(new FakeAction<int>(2));
+
+            CollectionAssert.AreEqual(new[] { 1, 2 }, mockObserver.Values);
+        }
+    }
+}

--- a/src/Redux.Tests/Redux.Tests.csproj
+++ b/src/Redux.Tests/Redux.Tests.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FakeAction.cs" />
+    <Compile Include="Reactive\StoreExtensionsTests.cs" />
     <Compile Include="Reducers.cs" />
     <Compile Include="StoreTests.cs" />
     <Compile Include="MockObserver.cs" />

--- a/src/Redux/Reactive/StoreExtensions.cs
+++ b/src/Redux/Reactive/StoreExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Reactive.Linq;
+
+namespace Redux.Reactive
+{
+    public static class StoreExtensions
+    {
+        public static IObservable<T> ObserveState<T>(this IStore<T> store)
+        {
+            return Observable.FromEvent<T>(
+                h => store.StateChanged += h,
+                h => store.StateChanged -= h);
+        }
+    }
+}

--- a/src/Redux/Redux.csproj
+++ b/src/Redux/Redux.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Delegates.cs" />
     <Compile Include="IStore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Reactive\StoreExtensions.cs" />
     <Compile Include="Store.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I propose the solution 2 explained in this [comment ](https://github.com/GuillaumeSalles/redux.NET/issues/51#issuecomment-290222319)

I think it's the cleaner approach.

@cmeeren, you quoted this earlier :

> The Create method is also preferred over creating custom types that implement the IObservable interface. There really is no need to implement the observer/observable interfaces yourself. Rx tackles the intricacies that you may not think of such as thread safety of notifications and subscriptions.

I agree but for the solution 1, you don't have other choice if you want to have other method on your custom observable. 

Also, Observable.FromEvent is okay for our use case ([link](http://www.introtorx.com/Content/v1.0.10621.0/04_CreatingObservableSequences.html#FromEvent))

(I read this website in 2011 and it's still the best Rx reference 👌 )

What do you think ?