### PR TITLE
refactor GetState() to State property

### DIFF
--- a/src/Redux.DevTools/TimeMachineStore.cs
+++ b/src/Redux.DevTools/TimeMachineStore.cs
@@ -8,9 +8,12 @@
         {
         }
 
-        TState IStore<TState>.GetState()
+        TState IStore<TState>.State
         {
-            return Unlift(GetState());
+            get
+            {
+                return Unlift(State);
+            }
         }
 
         private TState Unlift(TimeMachineState state)

--- a/src/Redux.Tests/StoreTests.cs
+++ b/src/Redux.Tests/StoreTests.cs
@@ -12,7 +12,7 @@ namespace Redux.Tests
     {
         public static void SubscribeAndGetState<TState>(this IStore<TState> store, Action<TState> listener)
         {
-            store.StateChanged += () => listener(store.GetState());
+            store.StateChanged += () => listener(store.State);
         }
     }
     
@@ -96,7 +96,7 @@ namespace Redux.Tests
         {
             var sut = new Store<int>(Reducers.Replace, 1);
 
-            Assert.AreEqual(1, sut.GetState());
+            Assert.AreEqual(1, sut.State);
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace Redux.Tests
 
             sut.Dispatch(new FakeAction<int>(2));
 
-            Assert.AreEqual(2, sut.GetState());
+            Assert.AreEqual(2, sut.State);
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace Redux.Tests
             await Task.WhenAll(Enumerable.Range(0, 1000)
                 .Select(_ => Task.Factory.StartNew(() => sut.Dispatch(new FakeAction<int>(0)))));
 
-            Assert.AreEqual(1000, sut.GetState());
+            Assert.AreEqual(1000, sut.State);
         }
     }
 }

--- a/src/Redux/IStore.cs
+++ b/src/Redux/IStore.cs
@@ -29,7 +29,7 @@ namespace Redux
         /// <returns>
         ///     The current state tree.
         /// </returns>
-        TState GetState();
+        TState State { get; }
 
         event Action StateChanged;
     }

--- a/src/Redux/Reactive/StoreExtensions.cs
+++ b/src/Redux/Reactive/StoreExtensions.cs
@@ -11,7 +11,7 @@ namespace Redux.Reactive
                 .FromEvent(
                     h => store.StateChanged += h,
                     h => store.StateChanged -= h)
-                .Select(_ => store.GetState());
+                .Select(_ => store.State);
         }
     }
 }

--- a/src/Redux/Store.cs
+++ b/src/Redux/Store.cs
@@ -37,9 +37,12 @@ namespace Redux
             return _dispatcher(action);
         }
 
-        public TState GetState()
+        public TState State
         {
-            return _lastState;
+            get
+            {
+                return _lastState;
+            }
         }
 
         private Dispatcher ApplyMiddlewares(params Middleware<TState>[] middlewares)


### PR DESCRIPTION
See https://github.com/GuillaumeSalles/redux.NET/issues/59

Is this a satisfactory refactor? I also had a question, how do you feel about using newer syntax for the property in Store.cs: `public TState State => _lastState;`?