### PR TITLE
Prevent occurrence of Unhandled Exception in Xamarin Forms example

### DIFF
--- a/examples/todomvc/Redux.TodoMvc.Forms/App.cs
+++ b/examples/todomvc/Redux.TodoMvc.Forms/App.cs
@@ -25,6 +25,7 @@ namespace Redux.TodoMvc.Forms
 
             Store = new Store<ApplicationState>(initialState, Reducers.ReduceApplication);
 
+            masterDetail.Master = new ContentPage() {Title = "Redux.NET Example"};
             masterDetail.Detail =
                 new NavigationPage(
                     new MainPage() { Title = "Todo List" }


### PR DESCRIPTION
Added master page to prevent occurrence of Unhandled Exception: System.InvalidOperationException: Master and Detail must be set before adding MasterDetailPage to a container.